### PR TITLE
fix for npm >= 5.3.0, changed tempDir location to os.tmpDir()

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var TEMP_DIR = '.npmbundle' + path.sep
 var rimraf = require('rimraf')
 var ncp = require('ncp')
+var os = require('os')
 var glob = require('glob')
 var async = require('insync')
 var mkdirp = require('mkdirp')
@@ -158,7 +159,7 @@ function npmBundle (args, options, cb) {
   var argAndOptions = splitArgAndOptions(args)
   var verbose = options.verbose || false
   var startDir = process.cwd() + path.sep
-  var tempDir = startDir + TEMP_DIR
+  var tempDir = os.tmpdir() + path.sep + TEMP_DIR
   var templateDir = __dirname + path.sep + 'templates'
   var context = {
     installable: null,

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ function outputData (data) {
 
 function npmInstall (verbose, options, installable, next) {
   options = options.length ? ' ' + options.join(' ') : ''
+  installable = '"' + installable + '"'
   var command = 'npm i ' + installable + options + ' --legacy-bundling'
   var process = exec(command, function onNpmInstall (error, stdout) {
     next(error, stdout)


### PR DESCRIPTION
error when running npm-bundle with npm >= 5.3.0:
```$ npm-bundle
D:\Profiles\<PROFILE>\AppData\Roaming\npm\node_modules\npm-bundle\bin\cli.js:11
    throw error
    ^

Error: ENOENT: no such file or directory, open 'D:\<PATH>\.npmbundle\node_modules\<PROJECT>\package.json'
```

underlying reason of the problem: https://stackoverflow.com/questions/45555682/npm-install-local-package-creates-symbolik-link

turns out, that instead of copying the whole project contents when doing ```npm i <folder>```, npm creates symbolic link, after that ```rimraf``` was being called to remove ```.npmbundle``` from nested ```node_modules```; unfortunately, since it was a symlink, it also removed original tempdir contents and couldn't find original ```package.json``` and hence the error

what I did to fix it was just changing location of tempDir to os.tmpDir() instead of putting it within the project directory, that does the trick (at least works for me on Windows)
unfortunately, the fix is not 100% good, because it still operates on a symlink and due to that, after running npm-bundle, I end up with modified ```package.json``` in my project, with ```bundledDependencies``` appended