### PR TITLE
fix stderr maxBuffer error on npm pack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var exec = require('child_process').exec
+var spawn = require('child_process').spawn
 var fs = require('fs')
 var TEMP_DIR = '.npmbundle' + path.sep
 var rimraf = require('rimraf')
@@ -72,12 +73,12 @@ function npmInstall (verbose, options, installable, next) {
 }
 
 function npmPack (verbose, packable, next) {
-  var command = 'npm pack ' + packable
-  var process = exec(command, function onNpmPack (error, stdout) {
-    next(error, stdout)
-  })
+  var command = 'npm';
+  var args = ['pack', packable]
+  var pack = spawn(command, args)
   if (verbose) {
-    process.stdout.on('data', outputData)
+    pack.stdout.on('data', outputData)
+    pack.on('exit', () => console.log(command, args, 'finished'))
   }
 }
 


### PR DESCRIPTION
This fixes the following error, which occurs on the npm pack call because exec was used instead of spawn. Updated to use spawn and all is well.

```
~/.nvm/versions/node/v8.12.0/lib/node_modules/npm-bundle/bin/cli.js:11
    throw error
    ^

Error: stderr maxBuffer exceeded
    at Socket.onChildStderr (child_process.js:347:14)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:246:13)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at Pipe.onread (net.js:601:20)
```